### PR TITLE
Merge sfrinaldi/31-ci-edits into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ env:
 
 on:
   push: 
-    branches:
-      - main
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
@@ -64,7 +62,7 @@ jobs:
         run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
       - name: Update README.md
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref != 'refs/heads/main' && github.head_ref != '' }}
         run: |
           git fetch                         # fetch branches
           git config --global user.name 'GitHub Action'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 # Converts latex acronym format to a rough markdown template for easier viewing
 name: Markdown / Latex Acronym Workflow
 
+# CI Variables
+env:
+  COMPILED: compiled # Compiled Documents Branch Name
+
 on:
   push:
   pull_request:
@@ -67,17 +71,32 @@ jobs:
 
 
       - name: Update Compiled Branch
-        if: ${{ github.ref == 'refs/heads/main'}}
+        if: ${{ (github.ref == 'refs/heads/main') || ( github.head_ref != '' ) }}
         run: |
           git fetch origin compiled  --recurse-submodules=no  
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
-          git branch --track compiled origin/compiled        
+          git branch --track ${{env.COMPILED}}  origin/${{env.COMPILED}}        
           mkdir output
-          git worktree add output compiled                     
-          mv uasal-acronyms.md  output/uasal-acronyms.md
-          mv compiled-acronyms.pdf output/compiled-acronyms.pdf
+          git worktree add output ${{env.COMPILED}}  
+
+          echo "Checking trigger condition for workflow..."
+          if [[ "${{github.ref_name}}" == "main" ]]; then
+            echo "Running steps for main branch"
+            mv *.pdf  output/
+            mv *acronyms.md output/
+          elif [[ "${{ github.head_ref}}" != '' ]]; then
+            mkdir -p output/Pull_Requests/${{github.event.pull_request.number}}
+            mv *.pdf  output/
+            mv *acronyms.md output/
+          else
+            echo "Unknown exception hit that shouldn't be allowed unless CI variables or Trigger cases have been adjusted in compiled.yml"
+          fi
+
+          echo "Moving worktree and git adding."
           cd output                                            
           git add .                                         
-          git commit -m "Compiled documents created w/CI on main"                          
+          git commit -m "Compiled documentation from ${{github.ref_name}}"                        
           git push  
+        shell: bash
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           name: Markdown-Acronyms
           path: uasal-acronyms.md
+          retention-days: 7
 
       - name: Run LaTeX Script
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
   COMPILED: compiled # Compiled Documents Branch Name
 
 on:
-  push: 
+  push:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
       - name: Update README.md
-        if: ${{ github.ref != 'refs/heads/main' && github.head_ref != '' }}
+        if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'pull_request' }}
         run: |
           git fetch                         # fetch branches
           git config --global user.name 'GitHub Action'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: 
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
 
       - name: Import Libraries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ env:
   COMPILED: compiled # Compiled Documents Branch Name
 
 on:
-  push:
+  push: 
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
@@ -38,7 +40,9 @@ jobs:
         if: always()
         with:
           name: Markdown-Acronyms
-          path: uasal-acronyms.md
+          path: |
+            uasal-acronyms.md
+            *.pdf
           retention-days: 7
 
       - name: Run LaTeX Script
@@ -60,7 +64,7 @@ jobs:
         run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
       - name: Update README.md
-        if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'pull_request' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           git fetch                         # fetch branches
           git config --global user.name 'GitHub Action'
@@ -87,8 +91,8 @@ jobs:
             mv *acronyms.md output/
           elif [[ "${{ github.head_ref}}" != '' ]]; then
             mkdir -p output/Pull_Requests/${{github.event.pull_request.number}}
-            mv *.pdf  output/
-            mv *acronyms.md output/
+            mv *.pdf  output/Pull_Requests/${{github.event.pull_request.number}}
+            mv *acronyms.md output/Pull_Requests/${{github.event.pull_request.number}}
           else
             echo "Unknown exception hit that shouldn't be allowed unless CI variables or Trigger cases have been adjusted in compiled.yml"
           fi
@@ -99,4 +103,3 @@ jobs:
           git commit -m "Compiled documentation from ${{github.ref_name}}"                        
           git push  
         shell: bash
-        

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ This repository outputs the results of the workflow for this repo to the [compil
 - POC -> POC -> point of contact
 - CDRL -> CDRL -> Contract Data Requirement List
 - FBD -> FBD -> Functional Block Diagram
-- MIUL -> MIUL -> FMaterials Identification and Usage List
+- MIUL -> MIUL -> Materials Identification and Usage List
 
 ---------------------------------
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ This repository outputs the results of the workflow for this repo to the [compil
 - TLE -> TLE -> Two Line Element set
 - TRL -> TRL -> technology readiness level
 - swap -> SWaP -> Size, Weight, and Power
+- tcsi -> TCSI -> Telescope Control System Interface
+- muf -> MUF -> Model Uncertainty Factor
+- AOCS -> AOCS -> Attitude and Orbit Control System
+- HSDR -> HSDR -> High Speed Data Recorder
 
 ---------------------------------
 
@@ -196,6 +200,7 @@ This repository outputs the results of the workflow for this repo to the [compil
 - WFS -> WFS -> wavefront sensor
 - LSI -> LSI -> Lateral Shearing Interferometer
 - VVC -> VVC -> Vector Vortex Coronagraph
+- VVW -> VVW -> Vector Vortex Waveplate
 - VNC -> VNC -> Visible Nulling Coronagraph
 - CGI -> CGI -> Coronagraph Instrument
 - IWA -> IWA -> Inner Working Angle
@@ -459,6 +464,7 @@ This repository outputs the results of the workflow for this repo to the [compil
 - POC -> POC -> point of contact
 - CDRL -> CDRL -> Contract Data Requirement List
 - FBD -> FBD -> Functional Block Diagram
+- MIUL -> MIUL -> FMaterials Identification and Usage List
 
 ---------------------------------
 

--- a/uasal-acronyms.tex
+++ b/uasal-acronyms.tex
@@ -400,7 +400,7 @@
 \newacronym{POC}{POC}{point of contact}
 \newacronym{CDRL}{CDRL}{Contract Data Requirement List}
 \newacronym{FBD}{FBD}{Functional Block Diagram}
-\newacronym{MIUL}{MIUL}{FMaterials Identification and Usage List}
+\newacronym{MIUL}{MIUL}{Materials Identification and Usage List}
 
 % SE / Systems Related
 \newacronym{PEL}{PEL}{Power Equipment List}


### PR DESCRIPTION
Applying ci edits to ci.yml via #31 and #32 issues for actions version increases and branch information functionality for ci process for latex doc. 

### Change Summary
_`ci.yml` Edits_
- Edit `actions/checkout` v4 -> v6
- Add `retention-days` to artifacts (7 days)
- Add `fetch-depth` to checkout action
- Add *.pdf to artifacts
- Add PR outputs for CI to push to compiled
- Turning auto gen of README back on
- Latex PDF branch fix for CI

Closes #31,#32 